### PR TITLE
Terminate with a newline

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,4 +30,5 @@ fn main() {
 
         stdout_handle.write(&*emoji).unwrap();
     }
+    stdout_handle.write("\n".as_bytes()).unwrap();
 }


### PR DESCRIPTION
I see a "%" character as the end of line in Terminal.app unless the unicode string is terminated with a newline character